### PR TITLE
Script fixes for arm64, defaults, min versions, clang

### DIFF
--- a/build_iphone.sh
+++ b/build_iphone.sh
@@ -3,7 +3,7 @@
 SCRATCH="scratch"
 DEST=`pwd`/"bin"
 
-ARCHS="armv7s armv7 x86_64"
+ARCHS="arm64 armv7 x86_64 i386"
 
 DEPLOYMENT_TARGET="6.0"
 
@@ -21,25 +21,39 @@ do
 	mkdir -p "$SCRATCH/$ARCH"
 	cd "$SCRATCH/$ARCH"
 
+	MIN_IOS_VERSION="${DEPLOYMENT_TARGET}"
+	if [[ "${ARCH}" == "arm64" || "${ARCH}" == "x86_64" ]]; then
+        MIN_IOS_VERSION=7.0 # 7.0 as this is the minimum for these architectures
+    elif [ "${ARCH}" == "i386" ]; then
+        MIN_IOS_VERSION=6.0 # 6.0 to prevent start linking errors
+    fi
+
 	if [ "$ARCH" = "i386" -o "$ARCH" = "x86_64" ]
 	then
 	    PLATFORM="iPhoneSimulator"
-	    IOS_CFLAGS="-arch $ARCH -mios-simulator-version-min=$DEPLOYMENT_TARGET"
+	    IOS_CFLAGS="-arch $ARCH -mios-simulator-version-min=$MIN_IOS_VERSION"
 	else
 	    PLATFORM="iPhoneOS"
-	    IOS_CFLAGS="-arch $ARCH -mios-version-min=$DEPLOYMENT_TARGET"
+	    IOS_CFLAGS="-arch $ARCH -mios-version-min=$MIN_IOS_VERSION"
 	fi	
+
+	HOST_TYPE="${ARCH}-apple-darwin"
+    if [ "${ARCH}" == "arm64" ]; then
+        # Fix unknown type for arm64 cpu (which is aarch64)
+        HOST_TYPE="aarch64-apple-darwin"
+    fi
+
 	export DEVELOPER=`xcode-select --print-path`
 	export DEVROOT="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
 	export SDKROOT="${DEVROOT}/SDKs/${PLATFORM}${IPHONE_SDK}.sdk"
-	export CC=`xcrun -find gcc`
+	export CC=`xcrun -find clang`
 	export LD=`xcrun -find ld`
 	export CFLAGS="-O3 ${IOS_CFLAGS} -isysroot ${SDKROOT}"
 	export LDFLAGS="${IOS_CFLAGS} -isysroot ${SDKROOT}"
 	export CPPFLAGS="${CFLAGS}"
 
 	$CWD/configure \
-	    --host="${ARCH}-apple-darwin" \
+	    --host="${HOST_TYPE}" \
 	    --prefix="$DEST/$ARCH" \
 	    --without-lapack \
 	    --without-python \


### PR DESCRIPTION
- Fixed minimum target issues for arm64 / x86_64 (has to be minimum 7.0)
- Fixed unknown host “arm64-apple-darwin”. (fixed with CPU name
  `aarch64` for arm64)
- Changed default ARCHS to iOS Default standard achitectures (arm64, i386 added, armv7s removed)
- Changed to clang rather than gcc
