### PR TITLE
Enables Bitcode compilation

### DIFF
--- a/build_iphone.sh
+++ b/build_iphone.sh
@@ -30,7 +30,7 @@ do
 	    IOS_CFLAGS="-arch $ARCH -mios-simulator-version-min=$MIN_IOS_VERSION"
 	else
 	    PLATFORM="iPhoneOS"
-	    IOS_CFLAGS="-arch $ARCH -mios-version-min=$MIN_IOS_VERSION"
+	    IOS_CFLAGS="-arch $ARCH -mios-version-min=$MIN_IOS_VERSION -fembed-bitcode"
 	fi	
 
 	HOST_TYPE="${ARCH}-apple-darwin"


### PR DESCRIPTION
Since bitcode is set as default in newer Xcode versions and that bitcode is supported from iOS 6 onwards it makes sense to enabled it so current projects benefit from it.